### PR TITLE
[Dokumentation] Release 2.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ API Definition zum Auslesen von Vorgängen aus der Europace-Plattform aus Sicht 
 
 # Dokumentation
 
-*Aktuelle Version: 2.12*
+*Aktuelle Version: 2.14*
 
 ### Swagger Spezifikationen
 Die API ist vollständig in Swagger definiert. Die Swagger Definitionen werden sowohl im JSON- ([swagger.json](swagger.json)) als auch im YAML-Format ([swagger.yaml](swagger.yaml)) zur Verfügung gestellt.

--- a/dokumentation/index.html
+++ b/dokumentation/index.html
@@ -688,7 +688,7 @@ table.CodeRay td.code>pre{padding:0}
 <div class="sect2">
 <h3 id="_aktuelle_version">Aktuelle Version</h3>
 <div class="paragraph">
-<p><em>Version</em> : 2.12</p>
+<p><em>Version</em> : 2.14</p>
 </div>
 </div>
 <div class="sect2">
@@ -3386,6 +3386,24 @@ table.CodeRay td.code>pre{padding:0}
 </tr>
 <tr>
 <td class="tableblock halign-left valign-middle"><div><div class="paragraph">
+<p><strong>riesterFoerderung</strong><br>
+<em>optional</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div><div class="paragraph">
+<p>boolean</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-middle"><div><div class="paragraph">
+<p><strong>riesterGefoerdertePerson</strong><br>
+<em>optional</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div><div class="paragraph">
+<p>string</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-middle"><div><div class="paragraph">
 <p><strong>sondertilgungOptionalJaehrlich</strong><br>
 <em>optional</em></p>
 </div></div></td>
@@ -3779,6 +3797,16 @@ table.CodeRay td.code>pre{padding:0}
 </tr>
 <tr>
 <td class="tableblock halign-left valign-middle"><div><div class="paragraph">
+<p><strong>bruttoJahresEinkommenErwartet</strong><br>
+<em>optional</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div></div></td>
+<td class="tableblock halign-left valign-middle"><div><div class="paragraph">
+<p>number</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-middle"><div><div class="paragraph">
 <p><strong>bruttoVorjahresEinkommen</strong><br>
 <em>optional</em></p>
 </div></div></td>
@@ -3903,6 +3931,16 @@ table.CodeRay td.code>pre{padding:0}
 <td class="tableblock halign-left valign-middle"><div></div></td>
 <td class="tableblock halign-left valign-middle"><div><div class="paragraph">
 <p><a href="#_schufaergebnis">SchufaErgebnis</a></p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-middle"><div><div class="paragraph">
+<p><strong>sozialversicherungsnummer</strong><br>
+<em>optional</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div></div></td>
+<td class="tableblock halign-left valign-middle"><div><div class="paragraph">
+<p>string</p>
 </div></div></td>
 </tr>
 <tr>
@@ -4403,6 +4441,18 @@ table.CodeRay td.code>pre{padding:0}
 </tr>
 <tr>
 <td class="tableblock halign-left valign-middle"><div><div class="paragraph">
+<p><strong>sparBeginn</strong><br>
+<em>optional</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div><div class="paragraph">
+<p>Der berechnete Beginn des Besparens des Bausparvertrags.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div><div class="paragraph">
+<p>string (date)</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-middle"><div><div class="paragraph">
 <p><strong>sparPhase</strong><br>
 <em>optional</em></p>
 </div></div></td>
@@ -4640,6 +4690,16 @@ table.CodeRay td.code>pre{padding:0}
 </tr>
 <tr>
 <td class="tableblock halign-left valign-middle"><div><div class="paragraph">
+<p><strong>riesterFoerderung</strong><br>
+<em>optional</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div></div></td>
+<td class="tableblock halign-left valign-middle"><div><div class="paragraph">
+<p>boolean</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-middle"><div><div class="paragraph">
 <p><strong>sonderZahlungEinmalig</strong><br>
 <em>optional</em></p>
 </div></div></td>
@@ -4718,6 +4778,16 @@ table.CodeRay td.code>pre{padding:0}
 <td class="tableblock halign-left valign-middle"><div></div></td>
 <td class="tableblock halign-left valign-middle"><div><div class="paragraph">
 <p>enum (ZINS_ABSICHERUNG, TILGUNGS_AUSGESETZT)</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-middle"><div><div class="paragraph">
+<p><strong>verwendungZulagen</strong><br>
+<em>optional</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div></div></td>
+<td class="tableblock halign-left valign-middle"><div><div class="paragraph">
+<p>enum (SONDERZAHLUNG, VERRECHNUNG)</p>
 </div></div></td>
 </tr>
 <tr>
@@ -4829,6 +4899,18 @@ table.CodeRay td.code>pre{padding:0}
 <td class="tableblock halign-left valign-middle"><div></div></td>
 <td class="tableblock halign-left valign-middle"><div><div class="paragraph">
 <p>&lt; <a href="#_sonderzahlung">SonderZahlung</a> &gt; array</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-middle"><div><div class="paragraph">
+<p><strong>sparBeginn</strong><br>
+<em>optional</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div><div class="paragraph">
+<p>Der berechnete Beginn des Besparens des Bausparvertrags.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div><div class="paragraph">
+<p>string (date)</p>
 </div></div></td>
 </tr>
 <tr>
@@ -6490,6 +6572,16 @@ table.CodeRay td.code>pre{padding:0}
 </div></div></td>
 <td class="tableblock halign-left valign-middle"><div><div class="paragraph">
 <p>number</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-middle"><div><div class="paragraph">
+<p><strong>riesterGefoerdert</strong><br>
+<em>optional</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div></div></td>
+<td class="tableblock halign-left valign-middle"><div><div class="paragraph">
+<p>boolean</p>
 </div></div></td>
 </tr>
 <tr>
@@ -12915,7 +13007,7 @@ table.CodeRay td.code>pre{padding:0}
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2020-01-28 11:25:03 MEZ
+Last updated 2020-02-19 17:01:23 MEZ
 </div>
 </div>
 </body>

--- a/swagger.json
+++ b/swagger.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "description": "Mit dieser API können die Vorgänge aus der Europace Plattform ausgelesen werden.",
-    "version": "2.12",
+    "version": "2.14",
     "title": "Vorgänge API",
     "contact": {
       "name": "Europace AG",
@@ -1088,6 +1088,12 @@
         "provision": {
           "type": "number"
         },
+        "riesterFoerderung": {
+          "type": "boolean"
+        },
+        "riesterGefoerdertePerson": {
+          "type": "string"
+        },
         "sondertilgungOptionalJaehrlich": {
           "type": "number"
         },
@@ -1285,6 +1291,9 @@
         "beschaeftigung": {
           "$ref": "#/definitions/Beschaeftigung"
         },
+        "bruttoJahresEinkommenErwartet": {
+          "type": "number"
+        },
         "bruttoVorjahresEinkommen": {
           "type": "number"
         },
@@ -1338,6 +1347,9 @@
         },
         "schufaErgebnis": {
           "$ref": "#/definitions/SchufaErgebnis"
+        },
+        "sozialversicherungsnummer": {
+          "type": "string"
         },
         "staatsangehoerigkeit": {
           "$ref": "#/definitions/Staat"
@@ -1548,6 +1560,12 @@
             "$ref": "#/definitions/SonderZahlung"
           }
         },
+        "sparBeginn": {
+          "type": "string",
+          "format": "date",
+          "description": "Der berechnete Beginn des Besparens des Bausparvertrags.",
+          "allowEmptyValue": false
+        },
         "sparPhase": {
           "$ref": "#/definitions/SparPhase"
         },
@@ -1641,6 +1659,9 @@
         "id": {
           "type": "string"
         },
+        "riesterFoerderung": {
+          "type": "boolean"
+        },
         "sonderZahlungEinmalig": {
           "type": "number"
         },
@@ -1676,6 +1697,13 @@
           "enum": [
             "ZINS_ABSICHERUNG",
             "TILGUNGS_AUSGESETZT"
+          ]
+        },
+        "verwendungZulagen": {
+          "type": "string",
+          "enum": [
+            "SONDERZAHLUNG",
+            "VERRECHNUNG"
           ]
         },
         "zuteilungsDatum": {
@@ -1718,6 +1746,12 @@
           "items": {
             "$ref": "#/definitions/SonderZahlung"
           }
+        },
+        "sparBeginn": {
+          "type": "string",
+          "format": "date",
+          "description": "Der berechnete Beginn des Besparens des Bausparvertrags.",
+          "allowEmptyValue": false
         },
         "sparPhase": {
           "$ref": "#/definitions/SparPhase"
@@ -2519,6 +2553,9 @@
           "type": "number",
           "description": "nur bei darlehensTyp==KFW_DARLEHEN",
           "allowEmptyValue": false
+        },
+        "riesterGefoerdert": {
+          "type": "boolean"
         },
         "sollZins": {
           "type": "number",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3,7 +3,7 @@ swagger: "2.0"
 info:
   description: "Mit dieser API können die Vorgänge aus der Europace Plattform ausgelesen\
     \ werden."
-  version: "2.12"
+  version: "2.14"
   title: "Vorgänge API"
   contact:
     name: "Europace AG"
@@ -722,6 +722,10 @@ definitions:
         type: "number"
       provision:
         type: "number"
+      riesterFoerderung:
+        type: "boolean"
+      riesterGefoerdertePerson:
+        type: "string"
       sondertilgungOptionalJaehrlich:
         type: "number"
       tilgungsWunsch:
@@ -859,6 +863,8 @@ definitions:
         description: "wenn Aufenthaltstitel befristet"
       beschaeftigung:
         $ref: "#/definitions/Beschaeftigung"
+      bruttoJahresEinkommenErwartet:
+        type: "number"
       bruttoVorjahresEinkommen:
         type: "number"
       email:
@@ -897,6 +903,8 @@ definitions:
         type: "string"
       schufaErgebnis:
         $ref: "#/definitions/SchufaErgebnis"
+      sozialversicherungsnummer:
+        type: "string"
       staatsangehoerigkeit:
         $ref: "#/definitions/Staat"
       steuerId:
@@ -1041,6 +1049,10 @@ definitions:
         type: "array"
         items:
           $ref: "#/definitions/SonderZahlung"
+      sparBeginn:
+        type: "string"
+        format: "date"
+        description: "Der berechnete Beginn des Besparens des Bausparvertrags."
       sparPhase:
         $ref: "#/definitions/SparPhase"
       tarif:
@@ -1106,6 +1118,8 @@ definitions:
           type: "string"
       id:
         type: "string"
+      riesterFoerderung:
+        type: "boolean"
       sonderZahlungEinmalig:
         type: "number"
       sonderZahlungen:
@@ -1131,6 +1145,11 @@ definitions:
         enum:
         - "ZINS_ABSICHERUNG"
         - "TILGUNGS_AUSGESETZT"
+      verwendungZulagen:
+        type: "string"
+        enum:
+        - "SONDERZAHLUNG"
+        - "VERRECHNUNG"
       zuteilungsDatum:
         type: "string"
         format: "date"
@@ -1161,6 +1180,10 @@ definitions:
         type: "array"
         items:
           $ref: "#/definitions/SonderZahlung"
+      sparBeginn:
+        type: "string"
+        format: "date"
+        description: "Der berechnete Beginn des Besparens des Bausparvertrags."
       sparPhase:
         $ref: "#/definitions/SparPhase"
       tarif:
@@ -1747,6 +1770,8 @@ definitions:
       rateMonatlichInDerTilgungsfreienAnlaufzeit:
         type: "number"
         description: "nur bei darlehensTyp==KFW_DARLEHEN"
+      riesterGefoerdert:
+        type: "boolean"
       sollZins:
         type: "number"
         example: 2.05


### PR DESCRIPTION
- Neue Felder zur Riesterförderung:
  - riesterFoerderung und riesterGefoerdertePerson am AnnuitaetenDarlehensWunsch
  - bruttoJahresEinkommenErwartet und sozialversicherungsnummer am Antragsteller
  - riesterFoerderung und verwendungZulagen am BausparWunsch
  - riesterGefoerdert am Darlehen
- Erweiterung für Sparbeginn: sparBeginn am BausparAngebot und Bausparvertrag