### PR TITLE
[Beratung#298] Finanzierungsvorschläge per API nun mit Echtdaten

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ API Definition zum Auslesen von Vorgängen aus der Europace-Plattform aus Sicht 
 
 # Dokumentation
 
-*Aktuelle Version: 2.15*
+*Aktuelle Version: 2.16*
+
 
 ### Swagger Spezifikationen
 Die API ist vollständig in Swagger definiert. Die Swagger Definitionen werden sowohl im JSON- ([swagger.json](swagger.json)) als auch im YAML-Format ([swagger.yaml](swagger.yaml)) zur Verfügung gestellt.

--- a/dokumentation/index.html
+++ b/dokumentation/index.html
@@ -583,16 +583,16 @@ table.CodeRay td.code>pre{padding:0}
 <li><a href="#_beratung">Beratung</a></li>
 <li><a href="#_berechnungshilfebetrag">BerechnungsHilfeBetrag</a></li>
 <li><a href="#_bereitstellung">Bereitstellung</a></li>
-<li><a href="#_bereitstellungszinsfreiezeitpraeferenz">BereitstellungsZinsFreieZeitPraeferenz</a></li>
-<li><a href="#_beschaeftigung">Beschaeftigung</a></li>
-<li><a href="#_bestandteilederfinanzierungpraeferenz">BestandteileDerFinanzierungPraeferenz</a></li>
-<li><a href="#_bestehendeimmobilie">BestehendeImmobilie</a></li>
-<li><a href="#_bestehenderbausparvertrag">BestehenderBausparvertrag</a></li>
-<li><a href="#_bestehendesdarlehen">BestehendesDarlehen</a></li>
-<li><a href="#_bestehendesdarlehendesfinanzierungsobjekts">BestehendesDarlehenDesFinanzierungsObjekts</a></li>
-<li><a href="#_charsequence">CharSequence</a></li>
-<li><a href="#_darlehen">Darlehen</a></li>
-<li><a href="#_darlehenswunsch">DarlehensWunsch</a></li>
+    <li><a href="#_bereitstellungszinsfreiezeitpraeferenz">BereitstellungsZinsFreieZeitPraeferenz</a></li>
+    <li><a href="#_beschaeftigung">Beschaeftigung</a></li>
+    <li><a href="#_bestandteilederfinanzierungpraeferenz">BestandteileDerFinanzierungPraeferenz</a></li>
+    <li><a href="#_bestehendeimmobilie">BestehendeImmobilie</a></li>
+    <li><a href="#_bestehenderbausparvertrag">BestehenderBausparvertrag</a></li>
+    <li><a href="#_bestehendesdarlehen">BestehendesDarlehen</a></li>
+    <li><a href="#_bestehendesdarlehendesfinanzierungsobjekts">BestehendesDarlehenDesFinanzierungsObjekts</a></li>
+    <li><a href="#_charsequence">CharSequence</a></li>
+    <li><a href="#_darlehen">Darlehen</a></li>
+    <li><a href="#_darlehenswunsch">DarlehensWunsch</a></li>
     <li><a href="#_dokument">Dokument</a></li>
     <li><a href="#_effektivzinserhoehendekosten">EffektivZinsErhoehendeKosten</a></li>
     <li><a href="#_effektivzinskosten">EffektivZinsKosten</a></li>
@@ -605,6 +605,7 @@ table.CodeRay td.code>pre{padding:0}
     <li><a href="#_finanzierungsobjekt">FinanzierungsObjekt</a></li>
     <li><a href="#_finanzierungsvorschlaegeresource">FinanzierungsvorschlaegeResource</a></li>
     <li><a href="#_finanzierungsvorschlag">Finanzierungsvorschlag</a></li>
+    <li><a href="#_finanzierungsvorschlaghistorieneintrag">FinanzierungsvorschlagHistorienEintrag</a></li>
     <li><a href="#_finanzierungswunsch">Finanzierungswunsch</a></li>
     <li><a href="#_flurstueck">Flurstueck</a></li>
     <li><a href="#_forwarddarlehenswunsch">ForwardDarlehensWunsch</a></li>
@@ -615,16 +616,16 @@ table.CodeRay td.code>pre{padding:0}
     <li><a href="#_grundstueck">Grundstueck</a></li>
     <li><a href="#_haushalt">Haushalt</a></li>
     <li><a href="#_haushaltspositionen">HaushaltsPositionen</a></li>
-<li><a href="#_hoehederratepraeferenz">HoeheDerRatePraeferenz</a></li>
-<li><a href="#_immobilieverknuepfung">ImmobilieVerknuepfung</a></li>
-<li><a href="#_kfwdarlehenswunsch">KfwDarlehensWunsch</a></li>
-<li><a href="#_kind">Kind</a></li>
-<li><a href="#_laufzeitpraeferenz">LaufzeitPraeferenz</a></li>
-<li><a href="#_leadtracking">LeadTracking</a></li>
-<li><a href="#_lebensoderrentenversicherungvermoegen">LebensOderRentenversicherungVermoegen</a></li>
-<li><a href="#_legitimationsdaten">LegitimationsDaten</a></li>
-<li><a href="#_link">Link</a></li>
-<li><a href="#_links">Links</a></li>
+    <li><a href="#_hoehederratepraeferenz">HoeheDerRatePraeferenz</a></li>
+    <li><a href="#_immobilieverknuepfung">ImmobilieVerknuepfung</a></li>
+    <li><a href="#_kfwdarlehenswunsch">KfwDarlehensWunsch</a></li>
+    <li><a href="#_kind">Kind</a></li>
+    <li><a href="#_laufzeitpraeferenz">LaufzeitPraeferenz</a></li>
+    <li><a href="#_leadtracking">LeadTracking</a></li>
+    <li><a href="#_lebensoderrentenversicherungvermoegen">LebensOderRentenversicherungVermoegen</a></li>
+    <li><a href="#_legitimationsdaten">LegitimationsDaten</a></li>
+    <li><a href="#_link">Link</a></li>
+    <li><a href="#_links">Links</a></li>
 <li><a href="#_meldung">Meldung</a></li>
 <li><a href="#_mietausgaben">MietAusgaben</a></li>
 <li><a href="#_miteigentumsanteil">MiteigentumsAnteil</a></li>
@@ -699,7 +700,7 @@ table.CodeRay td.code>pre{padding:0}
 <div class="sect2">
 <h3 id="_aktuelle_version">Aktuelle Version</h3>
 <div class="paragraph">
-    <p><em>Version</em> : 2.15</p>
+    <p><em>Version</em> : 2.16</p>
 </div>
 </div>
 <div class="sect2">
@@ -2426,12 +2427,20 @@ table.CodeRay td.code>pre{padding:0}
 <td class="tableblock halign-left valign-middle"><div><div class="paragraph">
 <p><strong>504</strong></p>
 </div></div></td>
-<td class="tableblock halign-left valign-middle"><div><div class="paragraph">
-<p>Gateway Timeout</p>
-</div></div></td>
-<td class="tableblock halign-left valign-middle"><div><div class="paragraph">
-<p><a href="#_error">Error</a></p>
-</div></div></td>
+    <td class="tableblock halign-left valign-middle">
+        <div>
+            <div class="paragraph">
+                <p>Gateway Timeout</p>
+            </div>
+        </div>
+    </td>
+    <td class="tableblock halign-left valign-middle">
+        <div>
+            <div class="paragraph">
+                <p><a href="#_error">Error</a></p>
+            </div>
+        </div>
+    </td>
 </tr>
 </tbody>
 </table>
@@ -3466,16 +3475,22 @@ table.CodeRay td.code>pre{padding:0}
                         <div>
                             <div class="paragraph">
                                 <p><strong><a href="#_oauth2">oauth2</a></strong></p>
-</div></div></td>
-<td class="tableblock halign-left valign-middle"><div><div class="paragraph">
-<p>API</p>
-</div></div></td>
-</tr>
-</tbody>
-</table>
-</div>
-</div>
-<div class="sect3">
+                            </div>
+                        </div>
+                    </td>
+                    <td class="tableblock halign-left valign-middle">
+                        <div>
+                            <div class="paragraph">
+                                <p>API</p>
+                            </div>
+                        </div>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+    <div class="sect3">
 <h4 id="_updatekundenbetreuerusingput">Den Kundenbetreuer ändern</h4>
 <div class="literalblock">
 <div class="content">
@@ -5409,7 +5424,13 @@ table.CodeRay td.code>pre{padding:0}
 <p><strong>einmalzahlung</strong><br>
 <em>optional</em></p>
 </div></div></td>
-<td class="tableblock halign-left valign-middle"><div></div></td>
+    <td class="tableblock halign-left valign-middle">
+        <div>
+            <div class="paragraph">
+                <p>Deprecated. Einmalzahlungen sind Teil der Sonderzahlungen.</p>
+            </div>
+        </div>
+    </td>
 <td class="tableblock halign-left valign-middle"><div><div class="paragraph">
 <p>number</p>
 </div></div></td>
@@ -5708,7 +5729,13 @@ table.CodeRay td.code>pre{padding:0}
 <p><strong>sonderZahlungEinmalig</strong><br>
 <em>optional</em></p>
 </div></div></td>
-<td class="tableblock halign-left valign-middle"><div></div></td>
+    <td class="tableblock halign-left valign-middle">
+        <div>
+            <div class="paragraph">
+                <p>Deprecated. Einmalzahlungen sind Teil der Sonderzahlungen.</p>
+            </div>
+        </div>
+    </td>
 <td class="tableblock halign-left valign-middle"><div><div class="paragraph">
 <p>number</p>
 </div></div></td>
@@ -5861,7 +5888,13 @@ table.CodeRay td.code>pre{padding:0}
 <p><strong>einmalzahlung</strong><br>
 <em>optional</em></p>
 </div></div></td>
-<td class="tableblock halign-left valign-middle"><div></div></td>
+    <td class="tableblock halign-left valign-middle">
+        <div>
+            <div class="paragraph">
+                <p>Deprecated. Einmalzahlungen sind Teil der Sonderzahlungen.</p>
+            </div>
+        </div>
+    </td>
 <td class="tableblock halign-left valign-middle"><div><div class="paragraph">
 <p>number</p>
 </div></div></td>
@@ -6114,6 +6147,23 @@ table.CodeRay td.code>pre{padding:0}
 <td class="tableblock halign-left valign-middle"><div><div class="paragraph">
 <p><a href="#_immobilieverknuepfung">ImmobilieVerknuepfung</a></p>
 </div></div></td>
+</tr>
+<tr>
+    <td class="tableblock halign-left valign-middle">
+        <div>
+            <div class="paragraph">
+                <p><strong>produktAnbieter</strong><br>
+                    <em>optional</em></p>
+            </div>
+        </div>
+    </td>
+    <td class="tableblock halign-left valign-middle">
+        <div>
+            <div class="paragraph">
+                <p><a href="#_produktanbieter">ProduktAnbieter</a></p>
+            </div>
+        </div>
+    </td>
 </tr>
 </tbody>
 </table>
@@ -6841,7 +6891,13 @@ table.CodeRay td.code>pre{padding:0}
 <p><strong>einmalzahlung</strong><br>
 <em>optional</em></p>
 </div></div></td>
-<td class="tableblock halign-left valign-middle"><div></div></td>
+    <td class="tableblock halign-left valign-middle">
+        <div>
+            <div class="paragraph">
+                <p>Deprecated. Einmalzahlungen sind Teil der Sonderzahlungen.</p>
+            </div>
+        </div>
+    </td>
 <td class="tableblock halign-left valign-middle"><div><div class="paragraph">
 <p>number</p>
 </div></div></td>
@@ -8301,7 +8357,11 @@ table.CodeRay td.code>pre{padding:0}
                     </div>
                 </td>
                 <td class="tableblock halign-left valign-middle">
-                    <div></div>
+                    <div>
+                        <div class="paragraph">
+                            <p>Deprecated. Einmalzahlungen sind Teil der Sonderzahlungen.</p>
+                        </div>
+                    </div>
                 </td>
                 <td class="tableblock halign-left valign-middle">
                     <div>
@@ -8585,16 +8645,16 @@ table.CodeRay td.code>pre{padding:0}
                 <col style="width: 16.6666%;">
                 <col style="width: 61.1111%;">
                 <col style="width: 22.2223%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-middle">Name</th>
-<th class="tableblock halign-left valign-middle">Beschreibung</th>
-<th class="tableblock halign-left valign-middle">Typ</th>
-</tr>
-</thead>
-<tbody>
-<tr>
+            </colgroup>
+            <thead>
+            <tr>
+                <th class="tableblock halign-left valign-middle">Name</th>
+                <th class="tableblock halign-left valign-middle">Beschreibung</th>
+                <th class="tableblock halign-left valign-middle">Typ</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
 <td class="tableblock halign-left valign-middle"><div><div class="paragraph">
 <p><strong>anzahlTeilzahlungen</strong><br>
 <em>optional</em></p>
@@ -9044,12 +9104,14 @@ table.CodeRay td.code>pre{padding:0}
 </div></div></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-middle"><div><div class="paragraph">
-<p><strong>wohnlage</strong><br>
-<em>optional</em></p>
-</div>
-</div>
-</td>
+    <td class="tableblock halign-left valign-middle">
+        <div>
+            <div class="paragraph">
+                <p><strong>wohnlage</strong><br>
+                    <em>optional</em></p>
+            </div>
+        </div>
+    </td>
     <td class="tableblock halign-left valign-middle">
         <div></div>
     </td>
@@ -9280,7 +9342,7 @@ table.CodeRay td.code>pre{padding:0}
                 <td class="tableblock halign-left valign-middle">
                     <div>
                         <div class="paragraph">
-                            <p><strong>erzeugtAm</strong><br>
+                            <p><strong>historie</strong><br>
                                 <em>optional</em></p>
                         </div>
                     </div>
@@ -9288,15 +9350,15 @@ table.CodeRay td.code>pre{padding:0}
                 <td class="tableblock halign-left valign-middle">
                     <div>
                         <div class="paragraph">
-                            <p>Datum, an welchem der Finanzierungsvorschlag erzeugt wurde.<br>
-                                <strong>Beispiel</strong> : <code>"2021-03-29T15:32:21.698Z"</code></p>
+                            <p>Historie, in der für jedes Aushändigen, ein Eintrag mit Datum und Akteur ausgegeben wird.</p>
                         </div>
                     </div>
                 </td>
                 <td class="tableblock halign-left valign-middle">
                     <div>
                         <div class="paragraph">
-                            <p>string (date-time)</p>
+                            <p>&lt; <a href="#_finanzierungsvorschlaghistorieneintrag">FinanzierungsvorschlagHistorienEintrag</a>
+                                &gt; array</p>
                         </div>
                     </div>
                 </td>
@@ -9448,6 +9510,60 @@ table.CodeRay td.code>pre{padding:0}
         </table>
     </div>
     <div class="sect2">
+        <h3 id="_finanzierungsvorschlaghistorieneintrag">FinanzierungsvorschlagHistorienEintrag</h3>
+        <div class="paragraph">
+            <p>Wird ein Angebot als Finanzierungsvorschlag ausgehändigt, wird ein Eintrag in die Historie geschrieben.</p>
+        </div>
+        <table class="tableblock frame-all grid-all spread">
+            <colgroup>
+                <col style="width: 42.8571%;">
+                <col style="width: 57.1429%;">
+            </colgroup>
+            <thead>
+            <tr>
+                <th class="tableblock halign-left valign-middle">Name</th>
+                <th class="tableblock halign-left valign-middle">Typ</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+                <td class="tableblock halign-left valign-middle">
+                    <div>
+                        <div class="paragraph">
+                            <p><strong>akteur</strong><br>
+                                <em>optional</em></p>
+                        </div>
+                    </div>
+                </td>
+                <td class="tableblock halign-left valign-middle">
+                    <div>
+                        <div class="paragraph">
+                            <p>string</p>
+                        </div>
+                    </div>
+                </td>
+            </tr>
+            <tr>
+                <td class="tableblock halign-left valign-middle">
+                    <div>
+                        <div class="paragraph">
+                            <p><strong>erzeugtAm</strong><br>
+                                <em>optional</em></p>
+                        </div>
+                    </div>
+                </td>
+                <td class="tableblock halign-left valign-middle">
+                    <div>
+                        <div class="paragraph">
+                            <p>string (date-time)</p>
+                        </div>
+                    </div>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+    <div class="sect2">
         <h3 id="_finanzierungswunsch">Finanzierungswunsch</h3>
         <table class="tableblock frame-all grid-all spread">
             <colgroup>
@@ -9458,16 +9574,22 @@ table.CodeRay td.code>pre{padding:0}
             <tr>
                 <th class="tableblock halign-left valign-middle">Name</th>
                 <th class="tableblock halign-left valign-middle">Typ</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-middle"><div><div class="paragraph">
-<p><strong>bausparWuensche</strong><br>
-<em>optional</em></p>
-</div></div></td>
-<td class="tableblock halign-left valign-middle"><div><div class="paragraph">
-<p>&lt; <a href="#_bausparwunsch">BausparWunsch</a> &gt; array</p>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+                <td class="tableblock halign-left valign-middle">
+                    <div>
+                        <div class="paragraph">
+                            <p><strong>bausparWuensche</strong><br>
+                                <em>optional</em></p>
+                        </div>
+                    </div>
+                </td>
+                <td class="tableblock halign-left valign-middle">
+                    <div>
+                        <div class="paragraph">
+                            <p>&lt; <a href="#_bausparwunsch">BausparWunsch</a> &gt; array</p>
 </div></div></td>
 </tr>
 <tr>
@@ -9995,16 +10117,26 @@ table.CodeRay td.code>pre{padding:0}
                         </div>
                     </div>
                 </td>
-<td class="tableblock halign-left valign-middle"><div></div></td>
-<td class="tableblock halign-left valign-middle"><div><div class="paragraph">
-<p>string</p>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-middle"><div><div class="paragraph">
-<p><strong>bandUndBlatt</strong><br>
-<em>optional</em></p>
-</div></div></td>
+                <td class="tableblock halign-left valign-middle">
+                    <div></div>
+                </td>
+                <td class="tableblock halign-left valign-middle">
+                    <div>
+                        <div class="paragraph">
+                            <p>string</p>
+                        </div>
+                    </div>
+                </td>
+            </tr>
+            <tr>
+                <td class="tableblock halign-left valign-middle">
+                    <div>
+                        <div class="paragraph">
+                            <p><strong>bandUndBlatt</strong><br>
+                                <em>optional</em></p>
+                        </div>
+                    </div>
+                </td>
 <td class="tableblock halign-left valign-middle"><div><div class="paragraph">
 <p>Angabe von Band und Blatt</p>
 </div></div></td>
@@ -14912,7 +15044,7 @@ table.CodeRay td.code>pre{padding:0}
 </div>
 <div id="footer">
 <div id="footer-text">
-    Last updated 2020-04-14 14:43:23 MESZ
+    Last updated 2020-06-08 12:23:14 MESZ
 </div>
 </div>
 </body>

--- a/swagger.json
+++ b/swagger.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "description": "Mit dieser API können die Vorgänge aus der Europace Plattform ausgelesen werden.",
-    "version": "2.15",
+    "version": "2.16",
     "title": "Vorgänge API",
     "contact": {
       "name": "Europace AG",
@@ -1790,7 +1790,9 @@
           "type": "number"
         },
         "einmalzahlung": {
-          "type": "number"
+          "type": "number",
+          "description": "Deprecated. Einmalzahlungen sind Teil der Sonderzahlungen.",
+          "allowEmptyValue": false
         },
         "id": {
           "type": "string"
@@ -1907,7 +1909,9 @@
           "type": "boolean"
         },
         "sonderZahlungEinmalig": {
-          "type": "number"
+          "type": "number",
+          "description": "Deprecated. Einmalzahlungen sind Teil der Sonderzahlungen.",
+          "allowEmptyValue": false
         },
         "sonderZahlungen": {
           "type": "array",
@@ -1973,7 +1977,9 @@
           "type": "number"
         },
         "einmalzahlung": {
-          "type": "number"
+          "type": "number",
+          "description": "Deprecated. Einmalzahlungen sind Teil der Sonderzahlungen.",
+          "allowEmptyValue": false
         },
         "gesamtLaufzeitInJahren": {
           "type": "integer",
@@ -2064,6 +2070,9 @@
         },
         "immobilie": {
           "$ref": "#/definitions/ImmobilieVerknuepfung"
+        },
+        "produktAnbieter": {
+          "$ref": "#/definitions/ProduktAnbieter"
         }
       },
       "title": "BeleihungsWert"
@@ -2466,7 +2475,9 @@
           "type": "number"
         },
         "einmalzahlung": {
-          "type": "number"
+          "type": "number",
+          "description": "Deprecated. Einmalzahlungen sind Teil der Sonderzahlungen.",
+          "allowEmptyValue": false
         },
         "ertrag": {
           "type": "number"
@@ -3054,7 +3065,9 @@
           "type": "number"
         },
         "einmalzahlung": {
-          "type": "number"
+          "type": "number",
+          "description": "Deprecated. Einmalzahlungen sind Teil der Sonderzahlungen.",
+          "allowEmptyValue": false
         },
         "gesamtLaufzeitInJahren": {
           "type": "integer",
@@ -3358,12 +3371,13 @@
           "description": "Aus allen Darlehens Effektivzinssätzen wird ein aggregierter Mischzins in Prozent ausgegeben.",
           "allowEmptyValue": false
         },
-        "erzeugtAm": {
-          "type": "string",
-          "format": "date-time",
-          "example": "2021-03-29T15:32:21.698Z",
-          "description": "Datum, an welchem der Finanzierungsvorschlag erzeugt wurde.",
-          "allowEmptyValue": false
+        "historie": {
+          "type": "array",
+          "description": "Historie, in der für jedes Aushändigen, ein Eintrag mit Datum und Akteur ausgegeben wird.",
+          "allowEmptyValue": false,
+          "items": {
+            "$ref": "#/definitions/FinanzierungsvorschlagHistorienEintrag"
+          }
         },
         "id": {
           "type": "string",
@@ -3405,6 +3419,20 @@
       },
       "title": "Finanzierungsvorschlag",
       "description": "Ein in BaufiSmart ausgehändigter Finanzierungsvorschlag."
+    },
+    "FinanzierungsvorschlagHistorienEintrag": {
+      "type": "object",
+      "properties": {
+        "akteur": {
+          "type": "string"
+        },
+        "erzeugtAm": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FinanzierungsvorschlagHistorienEintrag",
+      "description": "Wird ein Angebot als Finanzierungsvorschlag ausgehändigt, wird ein Eintrag in die Historie geschrieben."
     },
     "Finanzierungswunsch": {
       "type": "object",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3,7 +3,7 @@ swagger: "2.0"
 info:
   description: "Mit dieser API können die Vorgänge aus der Europace Plattform ausgelesen\
     \ werden."
-  version: "2.15"
+  version: "2.16"
   title: "Vorgänge API"
   contact:
     name: "Europace AG"
@@ -1209,6 +1209,7 @@ definitions:
         type: "number"
       einmalzahlung:
         type: "number"
+        description: "Deprecated. Einmalzahlungen sind Teil der Sonderzahlungen."
       id:
         type: "string"
       produktAnbieter:
@@ -1290,6 +1291,7 @@ definitions:
         type: "boolean"
       sonderZahlungEinmalig:
         type: "number"
+        description: "Deprecated. Einmalzahlungen sind Teil der Sonderzahlungen."
       sonderZahlungen:
         type: "array"
         items:
@@ -1337,6 +1339,7 @@ definitions:
         type: "number"
       einmalzahlung:
         type: "number"
+        description: "Deprecated. Einmalzahlungen sind Teil der Sonderzahlungen."
       gesamtLaufzeitInJahren:
         type: "integer"
         format: "int32"
@@ -1400,6 +1403,8 @@ definitions:
         type: "number"
       immobilie:
         $ref: "#/definitions/ImmobilieVerknuepfung"
+      produktAnbieter:
+        $ref: "#/definitions/ProduktAnbieter"
     title: "BeleihungsWert"
   Beratung:
     type: "object"
@@ -1704,6 +1709,7 @@ definitions:
         type: "number"
       einmalzahlung:
         type: "number"
+        description: "Deprecated. Einmalzahlungen sind Teil der Sonderzahlungen."
       ertrag:
         type: "number"
       id:
@@ -2108,6 +2114,7 @@ definitions:
         type: "number"
       einmalzahlung:
         type: "number"
+        description: "Deprecated. Einmalzahlungen sind Teil der Sonderzahlungen."
       gesamtLaufzeitInJahren:
         type: "integer"
         format: "int32"
@@ -2318,11 +2325,12 @@ definitions:
         example: 2.04
         description: "Aus allen Darlehens Effektivzinssätzen wird ein aggregierter\
           \ Mischzins in Prozent ausgegeben."
-      erzeugtAm:
-        type: "string"
-        format: "date-time"
-        example: "2021-03-29T15:32:21.698Z"
-        description: "Datum, an welchem der Finanzierungsvorschlag erzeugt wurde."
+      historie:
+        type: "array"
+        description: "Historie, in der für jedes Aushändigen, ein Eintrag mit Datum\
+          \ und Akteur ausgegeben wird."
+        items:
+          $ref: "#/definitions/FinanzierungsvorschlagHistorienEintrag"
       id:
         type: "string"
         description: "Id des Finanzierungsvorschlags"
@@ -2351,6 +2359,17 @@ definitions:
         $ref: "#/definitions/Links"
     title: "Finanzierungsvorschlag"
     description: "Ein in BaufiSmart ausgehändigter Finanzierungsvorschlag."
+  FinanzierungsvorschlagHistorienEintrag:
+    type: "object"
+    properties:
+      akteur:
+        type: "string"
+      erzeugtAm:
+        type: "string"
+        format: "date-time"
+    title: "FinanzierungsvorschlagHistorienEintrag"
+    description: "Wird ein Angebot als Finanzierungsvorschlag ausgehändigt, wird ein\
+      \ Eintrag in die Historie geschrieben."
   Finanzierungswunsch:
     type: "object"
     properties:


### PR DESCRIPTION
Motivation
Nutzer können sich per API die ausgehändigten FinVos (Echtdaten) auslesen

Changes
Swagger Dokumentation auf den aktuellen Microservice Stand angepasst. Dazu noch die statische API Referenz generiert. 

Ticket:
closes https://europace.atlassian.net/browse/BER-298