### PR TITLE
Boyscouting - Absolute Links zu Swagger-Dateien

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ API Definition zum Auslesen von Vorgängen aus der Europace-Plattform aus Sicht 
 
 
 ### Swagger Spezifikationen
-Die API ist vollständig in Swagger definiert. Die Swagger Definitionen werden sowohl im JSON- ([swagger.json](swagger.json)) als auch im YAML-Format ([swagger.yaml](swagger.yaml)) zur Verfügung gestellt.
+Die API ist vollständig in Swagger definiert. Die Swagger Definitionen werden sowohl im JSON- ([swagger.json](https://raw.githubusercontent.com/europace/baufismart-vorgaenge-api/master/swagger.json)) als auch im YAML-Format ([swagger.yaml](https://raw.githubusercontent.com/europace/baufismart-vorgaenge-api/master/swagger.yaml)) zur Verfügung gestellt.
 
 Diese Spezifikationen können auch zur Generierung von Clients für diese API verwendet
 werden. Dazu empfehlen wir das Tool [Swagger Codegen](https://github.com/swagger-api/swagger-codegen)


### PR DESCRIPTION
Auf https://developer.europace.de/api/vorgaenge-api/ führen die relativen Links für die Swagger-Dateien ins Nirvana.
Aufgrund dessen wurden hier die absoluten Pfade eingetragen.