### PR TITLE
Release 2.22 - TarifId in Bausparvertrag und EuropaceBausparAngebot

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "description": "Mit dieser API können die Vorgänge aus der Europace Plattform ausgelesen werden.",
-    "version": "2.21",
+    "version": "2.22",
     "title": "Vorgänge API",
     "contact": {
       "name": "Europace AG",
@@ -2137,6 +2137,11 @@
         "tarif": {
           "type": "string"
         },
+        "tarifId": {
+          "type": "string",
+          "description": "Produktanbieter-spezifische Tarif-ID des Bauspartarifs",
+          "allowEmptyValue": false
+        },
         "tilgungsPhase": {
           "$ref": "#/definitions/TilgungsPhase"
         },
@@ -3214,6 +3219,11 @@
         },
         "tarif": {
           "type": "string"
+        },
+        "tarifId": {
+          "type": "string",
+          "description": "Produktanbieter-spezifische Tarif-ID des Bauspartarifs",
+          "allowEmptyValue": false
         },
         "tilgungsPhase": {
           "$ref": "#/definitions/TilgungsPhase"

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3,7 +3,7 @@ swagger: "2.0"
 info:
   description: "Mit dieser API können die Vorgänge aus der Europace Plattform ausgelesen\
     \ werden."
-  version: "2.21"
+  version: "2.22"
   title: "Vorgänge API"
   contact:
     name: "Europace AG"
@@ -1450,6 +1450,9 @@ definitions:
         $ref: "#/definitions/SparPhase"
       tarif:
         type: "string"
+      tarifId:
+        type: "string"
+        description: "Produktanbieter-spezifische Tarif-ID des Bauspartarifs"
       tilgungsPhase:
         $ref: "#/definitions/TilgungsPhase"
       typ:
@@ -2220,6 +2223,9 @@ definitions:
         $ref: "#/definitions/SparPhase"
       tarif:
         type: "string"
+      tarifId:
+        type: "string"
+        description: "Produktanbieter-spezifische Tarif-ID des Bauspartarifs"
       tilgungsPhase:
         $ref: "#/definitions/TilgungsPhase"
       typ:


### PR DESCRIPTION
Änderungen in Version 2.22

Es gibt jeweils ein neues Feld `tarifId` im `Bausparvertrag` (Teil des Angebots) und `EuropaceBausparAngebot` (Teil des Finanzierungsvorschlags). Dieses enthält die produktanbieter-spezifische Tarif-ID des Bauspartarifs.

Beispiel-Responses:

Für `GET /v2/vorgaenge/{vorgangsNummer}/antraege/{antragsNummer}/{teilantragsNummer}`

```json
{
  "angebot": {
    // ...
    "bausparvertraege": [
      {
        "tarif": "BHW WohnBausparen (FI2N) 0,10% | 2,35%",
        "tarifId": "FI2N",
        "produktAnbieter": {
          "produktAnbieterId": "BHW"
          // ...
        }
        // ...
      }
    ]
    // ...
  }
}
```

Für `GET /v2/vorgaenge/{vorgangsNummer}/finanzierungsvorschlaege/{finanzierungsvorschlagId}`

```json
{
  // ...
  "bausparvertraege": [
    {
      "tarif": "BHW WohnBausparen (FI2N) 0,10% | 2,35%",
      "tarifId": "FI2N",
      "produktAnbieter": {
        "produktAnbieterId": "BHW"
        // ...
      }
      // ...
    }
  ]
  // ...
}
```