### PR TITLE
Release 2.23 - Anpassungen für neue KfW Programme 261 und 262

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "description": "Mit dieser API können die Vorgänge aus der Europace Plattform ausgelesen werden.",
-    "version": "2.22",
+    "version": "2.23",
     "title": "Vorgänge API",
     "contact": {
       "name": "Europace AG",
@@ -2839,15 +2839,34 @@
           "description": "nur bei darlehensTyp==FORWARD_DARLEHEN",
           "allowEmptyValue": false
         },
+        "kfwEnergieEffizienzGruppe": {
+          "type": "string",
+          "description": "nur bei darlehensTyp==KFW_DARLEHEN. Nur bei KfW-Programm 153, 261, 262.Es können auch weitere Werte zulässig werden.",
+          "allowEmptyValue": false,
+          "enum": [
+            "STANDARD",
+            "NEUBAU",
+            "SANIERUNG"
+          ]
+        },
         "kfwEnergieEffizienzStandard": {
           "type": "string",
-          "description": "nur bei darlehensTyp==KFW_DARLEHEN. Nur bei KfW-Programm 153 relevant. Bei neuen Energieeffizienzstandards können auch weitere Werte zulässig werden.",
+          "description": "nur bei darlehensTyp==KFW_DARLEHEN. Nur bei KfW-Programm 153, 261, 262 relevant. Bei neuen Energieeffizienzstandards können auch weitere Werte zulässig werden.",
           "allowEmptyValue": false,
           "enum": [
             "STANDARD_40_PLUS",
             "STANDARD_40",
+            "STANDARD_40_EEK",
             "STANDARD_55",
-            "STANDARD_70"
+            "STANDARD_55_EEK",
+            "STANDARD_70",
+            "STANDARD_70_EEK",
+            "STANDARD_85",
+            "STANDARD_85_EEK",
+            "STANDARD_100",
+            "STANDARD_100_EEK",
+            "STANDARD_DENKMAL",
+            "STANDARD_DENKMAL_EEK"
           ]
         },
         "kfwProgramm": {
@@ -2862,8 +2881,16 @@
             "PROGRAMM_153",
             "PROGRAMM_155",
             "PROGRAMM_159",
-            "PROGRAMM_167"
+            "PROGRAMM_167",
+            "PROGRAMM_261",
+            "PROGRAMM_262"
           ]
+        },
+        "kfwSanierungsFahrplanLiegtVor": {
+          "type": "boolean",
+          "example": false,
+          "description": "nur bei darlehensTyp==KFW_DARLEHEN. Nur bei KfW-Programm 261, 262 relevant.",
+          "allowEmptyValue": false
         },
         "konditionWurdeManuellAngepasst": {
           "type": "boolean"
@@ -4049,15 +4076,34 @@
             "ENDFAELLIG_EIGENES_ANGEBOT"
           ]
         },
+        "kfwEnergieEffizienzGruppe": {
+          "type": "string",
+          "description": "Nur bei Programm 153, 261, 262. Der Client muss mit unbekannten Werten umgehen können.",
+          "allowEmptyValue": false,
+          "enum": [
+            "STANDARD",
+            "NEUBAU",
+            "SANIERUNG"
+          ]
+        },
         "kfwEnergieEffizienzStandard": {
           "type": "string",
-          "description": "Nur bei Programm 153. Wenn die KfW-Bank neue Standards anerkennt, sind die entsprechenden neuen Ausprägungen zulässig. Der Client muss daher mit unbekannten Werten umgehen können.",
+          "description": "Nur bei Programm 153, 261, 262. Wenn die KfW-Bank neue Standards anerkennt, sind die entsprechenden neuen Ausprägungen zulässig. Der Client muss daher mit unbekannten Werten umgehen können.",
           "allowEmptyValue": false,
           "enum": [
             "STANDARD_40_PLUS",
             "STANDARD_40",
+            "STANDARD_40_EEK",
             "STANDARD_55",
-            "STANDARD_70"
+            "STANDARD_55_EEK",
+            "STANDARD_70",
+            "STANDARD_70_EEK",
+            "STANDARD_85",
+            "STANDARD_85_EEK",
+            "STANDARD_100",
+            "STANDARD_100_EEK",
+            "STANDARD_DENKMAL",
+            "STANDARD_DENKMAL_EEK"
           ]
         },
         "kfwProgramm": {
@@ -4072,8 +4118,16 @@
             "PROGRAMM_153",
             "PROGRAMM_155",
             "PROGRAMM_159",
-            "PROGRAMM_167"
+            "PROGRAMM_167",
+            "PROGRAMM_261",
+            "PROGRAMM_262"
           ]
+        },
+        "kfwSanierungsFahrplanLiegtVor": {
+          "type": "boolean",
+          "example": false,
+          "description": "Nur bei Programm 261, 262.",
+          "allowEmptyValue": false
         },
         "laufzeitInJahren": {
           "type": "integer",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3,7 +3,7 @@ swagger: "2.0"
 info:
   description: "Mit dieser API können die Vorgänge aus der Europace Plattform ausgelesen\
     \ werden."
-  version: "2.22"
+  version: "2.23"
   title: "Vorgänge API"
   contact:
     name: "Europace AG"
@@ -1963,16 +1963,33 @@ definitions:
         type: "integer"
         format: "int32"
         description: "nur bei darlehensTyp==FORWARD_DARLEHEN"
+      kfwEnergieEffizienzGruppe:
+        type: "string"
+        description: "nur bei darlehensTyp==KFW_DARLEHEN. Nur bei KfW-Programm 153,\
+          \ 261, 262.Es können auch weitere Werte zulässig werden."
+        enum:
+          - "STANDARD"
+          - "NEUBAU"
+          - "SANIERUNG"
       kfwEnergieEffizienzStandard:
         type: "string"
-        description: "nur bei darlehensTyp==KFW_DARLEHEN. Nur bei KfW-Programm 153\
-          \ relevant. Bei neuen Energieeffizienzstandards können auch weitere Werte\
-          \ zulässig werden."
+        description: "nur bei darlehensTyp==KFW_DARLEHEN. Nur bei KfW-Programm 153,\
+          \ 261, 262 relevant. Bei neuen Energieeffizienzstandards können auch weitere\
+          \ Werte zulässig werden."
         enum:
           - "STANDARD_40_PLUS"
           - "STANDARD_40"
+          - "STANDARD_40_EEK"
           - "STANDARD_55"
+          - "STANDARD_55_EEK"
           - "STANDARD_70"
+          - "STANDARD_70_EEK"
+          - "STANDARD_85"
+          - "STANDARD_85_EEK"
+          - "STANDARD_100"
+          - "STANDARD_100_EEK"
+          - "STANDARD_DENKMAL"
+          - "STANDARD_DENKMAL_EEK"
       kfwProgramm:
         type: "string"
         description: "nur bei darlehensTyp==KFW_DARLEHEN. Bei neu aufgelegten KfW-Programmen\
@@ -1986,6 +2003,13 @@ definitions:
           - "PROGRAMM_155"
           - "PROGRAMM_159"
           - "PROGRAMM_167"
+          - "PROGRAMM_261"
+          - "PROGRAMM_262"
+      kfwSanierungsFahrplanLiegtVor:
+        type: "boolean"
+        example: false
+        description: "nur bei darlehensTyp==KFW_DARLEHEN. Nur bei KfW-Programm 261,\
+          \ 262 relevant."
       konditionWurdeManuellAngepasst:
         type: "boolean"
       konditionsAnpassungsBegruendung:
@@ -2804,16 +2828,33 @@ definitions:
           - "NEIN"
           - "ENDFAELLIG_BERECHNET"
           - "ENDFAELLIG_EIGENES_ANGEBOT"
+      kfwEnergieEffizienzGruppe:
+        type: "string"
+        description: "Nur bei Programm 153, 261, 262. Der Client muss mit unbekannten\
+          \ Werten umgehen können."
+        enum:
+          - "STANDARD"
+          - "NEUBAU"
+          - "SANIERUNG"
       kfwEnergieEffizienzStandard:
         type: "string"
-        description: "Nur bei Programm 153. Wenn die KfW-Bank neue Standards anerkennt,\
-          \ sind die entsprechenden neuen Ausprägungen zulässig. Der Client muss daher\
-          \ mit unbekannten Werten umgehen können."
+        description: "Nur bei Programm 153, 261, 262. Wenn die KfW-Bank neue Standards\
+          \ anerkennt, sind die entsprechenden neuen Ausprägungen zulässig. Der Client\
+          \ muss daher mit unbekannten Werten umgehen können."
         enum:
           - "STANDARD_40_PLUS"
           - "STANDARD_40"
+          - "STANDARD_40_EEK"
           - "STANDARD_55"
+          - "STANDARD_55_EEK"
           - "STANDARD_70"
+          - "STANDARD_70_EEK"
+          - "STANDARD_85"
+          - "STANDARD_85_EEK"
+          - "STANDARD_100"
+          - "STANDARD_100_EEK"
+          - "STANDARD_DENKMAL"
+          - "STANDARD_DENKMAL_EEK"
       kfwProgramm:
         type: "string"
         description: "Bei neu aufgelegten KfW-Programmen können auch weitere Werte\
@@ -2828,6 +2869,12 @@ definitions:
           - "PROGRAMM_155"
           - "PROGRAMM_159"
           - "PROGRAMM_167"
+          - "PROGRAMM_261"
+          - "PROGRAMM_262"
+      kfwSanierungsFahrplanLiegtVor:
+        type: "boolean"
+        example: false
+        description: "Nur bei Programm 261, 262."
       laufzeitInJahren:
         type: "integer"
         format: "int32"


### PR DESCRIPTION
## Änderungen im Release 2.23

Ermöglicht die neuen KfW Programme 261 und 262. Mit den neuen Programmen gibt es neue Felder in den Objekten `KfwDarlehensWunsch` und `Darlehen`  im Typen `KFW_DARLEHEN`.

Neue Felder:

    kfwEnergieEffizienzGruppe
    kfwSanierungsFahrplanLiegtVor

Neue Werte:

    kfwProgramm
    kfwEnergieEffizienzStandard


Die KfW ordnet bei den neuen Programmen die EnergieEffizenzStandards jeweils verschiedenen Gruppen (NEUBAU, SANIERUNG) zu. Altfälle erhalten die Gruppe 'STANDARD'.

Die neuen Felder und Werte können ab dem 01.07.2021 auftreten.

Für `GET /v2/vorgaenge/{vorgangsNummer}`
```json
{
  "vorhaben": {
    "finanzierungswunsch": {
      "id": "60bf6e33aa46e863ccea17db",
      "darlehensWuensche": [
        {
          "kfwDarlehen": {
            "kfwProgramm": "PROGRAMM_261",
            "kfwEnergieEffizienzStandard": "STANDARD_70_EEK",
            "kfwEnergieEffizienzGruppe": "SANIERUNG",
            "kfwSanierungsFahrplanLiegtVor": true
          }
        }
      ]
    }
  }
}
```

Für `GET /v2/vorgaenge/{vorgangsNummer}/antraege/{antragsNummer}/{teilantragsNummer}`
```json
{
  "antraege": [
    {
      "angebot": {
        "darlehen": [
          {
            "darlehensTyp": "KFW_DARLEHEN",
            "kfwProgramm": "PROGRAMM_261",
            "kfwEnergieEffizienzStandard": "STANDARD_70_EEK",
            "kfwEnergieEffizienzGruppe": "SANIERUNG",
            "kfwSanierungsFahrplanLiegtVor": true
          }
        ]}
    }
  ]
}
```