### PR TITLE
[BD-839] Added ISO Code to documentation for Staat

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -5490,7 +5490,8 @@
       "type": "object",
       "properties": {
         "isoCountryCode": {
-          "type": "string"
+          "type": "string",
+          "description": "ISO 3166-1 alpha-2 code"
         },
         "name": {
           "type": "string"

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3873,6 +3873,7 @@ definitions:
     properties:
       isoCountryCode:
         type: string
+        description: ISO 3166-1 alpha-2 code
       name:
         type: string
     title: Staat


### PR DESCRIPTION
Closes [[BD-839]](https://europace.atlassian.net/browse/BD-839)
### Motivation
Es soll klar gemacht werden, um welche ISO Ländercodes es sich in der API handelt

### Änderungen
ISO Code als Beschreibung hinzugefügt



[BD-839]: https://europace.atlassian.net/browse/BD-839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ