### PR TITLE
MTV-10741 Add Github Workflows: Dependabot, Create PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "04:00"
+    open-pull-requests-limit: 10

--- a/.github/workflows/pr_on_push.yml
+++ b/.github/workflows/pr_on_push.yml
@@ -1,0 +1,20 @@
+name: Pull Request on Branch Push
+on:
+  push:
+    branches:
+      - "publish/*"
+jobs:
+  pull-request:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Expose git commit data
+        uses: rlespinasse/git-commit-data-action@v1.x
+      - name: pull-request
+        uses: repo-sync/pull-request@v2
+        with:
+          source_branch: ""                                 # If blank, default: triggered branch
+          destination_branch: "master"                      # If blank, default: master
+          pr_template: ".github/pull_request_template.md"
+          pr_assignee: ${{ env.GIT_COMMIT_COMMITTER_NAME }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
[MTV-10741]

## Motivation

Add Github Workflows that creates PRs from new pushed branches. This is used so when API-Docs of vorgaenge-edge-server changed a Github Workflow in vorgaenge-edge-server will push a new branch and therefore create a PR with the new API-Docs here.

[MTV-10741]: https://europace.atlassian.net/browse/MTV-10741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ