### PR TITLE
MTV-11168 Change uri to "https://baufinanzierung.api.europace.de"

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ example-response:
             "letzteAenderung": "2020-12-30T09:53:16.126Z",
             "_links": {
                 "self": {
-                    "href": "https://baufismart.api.europace.de/v3/vorgaenge/A74QK3"
+                    "href": "https://baufinanzierung.api.europace.de/v3/vorgaenge/A74QK3"
                 }
             }
         },
@@ -109,7 +109,7 @@ example-response:
             "letzteAenderung": "2020-12-30T09:53:15.331Z",
             "_links": {
                 "self": {
-                    "href": "https://baufismart.api.europace.de/v3/vorgaenge/ED7PIS"
+                    "href": "https://baufinanzierung.api.europace.de/v3/vorgaenge/ED7PIS"
                 }
             }
         },

--- a/openapi-v1.json
+++ b/openapi-v1.json
@@ -11,7 +11,7 @@
     "version" : "3.0"
   },
   "servers" : [ {
-    "url" : "https://baufismart.api.europace.de"
+    "url" : "https://baufinanzierung.api.europace.de"
   } ],
   "security" : [ {
     "oauth2" : [ ]

--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -9,7 +9,7 @@ info:
   title: Vorgänge API
   version: "3.0"
 servers:
-- url: https://baufismart.api.europace.de
+- url: https://baufinanzierung.api.europace.de
 security:
 - oauth2: []
 tags:

--- a/openapi-v2.json
+++ b/openapi-v2.json
@@ -11,7 +11,7 @@
     "version" : "3.0"
   },
   "servers" : [ {
-    "url" : "https://baufismart.api.europace.de"
+    "url" : "https://baufinanzierung.api.europace.de"
   } ],
   "security" : [ {
     "oauth2" : [ ]

--- a/openapi-v2.yaml
+++ b/openapi-v2.yaml
@@ -9,7 +9,7 @@ info:
   title: Vorgänge API
   version: "3.0"
 servers:
-- url: https://baufismart.api.europace.de
+- url: https://baufinanzierung.api.europace.de
 security:
 - oauth2: []
 tags:

--- a/openapi-v3.json
+++ b/openapi-v3.json
@@ -11,7 +11,7 @@
     "version" : "3.0"
   },
   "servers" : [ {
-    "url" : "https://baufismart.api.europace.de"
+    "url" : "https://baufinanzierung.api.europace.de"
   } ],
   "security" : [ {
     "oauth2" : [ ]

--- a/openapi-v3.yaml
+++ b/openapi-v3.yaml
@@ -9,7 +9,7 @@ info:
   title: Vorgänge API
   version: "3.0"
 servers:
-- url: https://baufismart.api.europace.de
+- url: https://baufinanzierung.api.europace.de
 security:
 - oauth2: []
 tags:

--- a/reference/index.html
+++ b/reference/index.html
@@ -2349,7 +2349,7 @@
         <div class="sect2">
           <h3 id="_uri_schema">URI Schema</h3>
           <div class="paragraph">
-            <p><em>Host</em> : https://baufismart.api.europace.de<br>
+            <p><em>Host</em> : https://baufinanzierung.api.europace.de<br>
               <em>Basis-Pfad</em> : /<br>
               <em>Schemata</em> : HTTPS</p>
           </div>


### PR DESCRIPTION
[MTV-11168]

## Motivation

It was decided that https://baufismart.api.europace.de should become https://baufinanzierung.api.europace.de.

[MTV-11168]: https://europace.atlassian.net/browse/MTV-11168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ